### PR TITLE
Fix #23 mem pool request args by adding "=true" for tz v7.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,11 +39,12 @@ func main() {
 	reg.MustRegister(collector.NewBuildInfoCollector(""))
 	reg.MustRegister(collector.NewNetworkCollector(service, *rpcTimeout, *chainID))
 	reg.MustRegister(collector.NewMempoolOperationsCollectorCollector(service, *chainID, []string{
-		"applied",
-		"branch_refused",
-		"refused",
-		"branch_delayed",
+		"applied=true",
+		"branch_refused=true",
+		"refused=true",
+		"branch_delayed=true",
 	}))
+
 
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 


### PR DESCRIPTION
It seem to add `=true` Fix the issue.
Load is normal

And I've theses metrics: `curl -s localhost:9489/metrics |grep  mempool`
```
# HELP tezos_node_mempool_operations_total The total number of mempool operations.
# TYPE tezos_node_mempool_operations_total counter
tezos_node_mempool_operations_total{kind="activate_account",pool="refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 6
tezos_node_mempool_operations_total{kind="endorsement",pool="applied=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 79
tezos_node_mempool_operations_total{kind="endorsement",pool="branch_delayed=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 79
tezos_node_mempool_operations_total{kind="endorsement",pool="branch_refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 79
tezos_node_mempool_operations_total{kind="endorsement",pool="refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 79
tezos_node_mempool_operations_total{kind="reveal",pool="applied=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 6
tezos_node_mempool_operations_total{kind="reveal",pool="branch_delayed=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 6
tezos_node_mempool_operations_total{kind="reveal",pool="branch_refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 12
tezos_node_mempool_operations_total{kind="reveal",pool="refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 6
tezos_node_mempool_operations_total{kind="transaction",pool="applied=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 12
tezos_node_mempool_operations_total{kind="transaction",pool="branch_delayed=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 12
tezos_node_mempool_operations_total{kind="transaction",pool="branch_refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 21
tezos_node_mempool_operations_total{kind="transaction",pool="refused=true",proto="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"} 12
# HELP tezos_rpc_mempool_monitor_connection_connect_duration_seconds Mempool monitor (re)connection duration (time until HTTP header arrives).
# TYPE tezos_rpc_mempool_monitor_connection_connect_duration_seconds histogram
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="0.25"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="0.5"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="1"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="2"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="4"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="8"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="16"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="32"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="64"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="128"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="256"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="512"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_bucket{le="+Inf"} 12
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_sum 0.0010227370000000001
tezos_rpc_mempool_monitor_connection_connect_duration_seconds_count 12
# HELP tezos_rpc_mempool_monitor_connection_total_duration_seconds The total life time of the mempool monitor RPC connection.
# TYPE tezos_rpc_mempool_monitor_connection_total_duration_seconds histogram
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="0.25"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="0.5"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="1"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="2"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="4"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="8"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="16"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="32"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="64"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="128"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="256"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="512"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_bucket{le="+Inf"} 12
tezos_rpc_mempool_monitor_connection_total_duration_seconds_sum 0.025576484999999996
tezos_rpc_mempool_monitor_connection_total_duration_seconds_count 12
```

I genuily don't know if I had change something in the behavior or if the mempool module need some rework.

It's take long to get http answer, in case of an http error it seem reasonable to add a delay before retrying ? no?